### PR TITLE
Update drone config to push to docker.io

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,3 +5,13 @@ notify:
   email:
     recipients:
       - drone@clever.com
+publish:
+  docker:
+    docker_file: Dockerfile
+    docker_server: {{docker_server}}
+    docker_port: 4243
+    docker_version: 0.10.0
+    repo_base_name: clever
+    username: {{username}}
+    password: {{password}}
+    email: {{email}}

--- a/.drone.yml
+++ b/.drone.yml
@@ -15,3 +15,4 @@ publish:
     username: {{username}}
     password: {{password}}
     email: {{email}}
+    branch: master


### PR DESCRIPTION
This change is a sample for how to add configuration to .drone.yaml to automatically
build a Docker image and push it to docker.io.

This is waiting on a few other changes before it can be pushed.
